### PR TITLE
fix content type problem

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,10 +2,11 @@
 <html>
 
 <head>
-    <title>{{page.title | default: "Scouts 226"}}</title>
+    <meta charset="UTF-8">  
     <meta name="keywords" content="troop 226, troop 226g, pack 226, troop, pack, 226, 226g, scouts, scouting, cbc">
-    <meta content="width=device-width, initial-scale=1" name="viewport" />
+    <meta content="width=device-width, initial-scale=1" name="viewport">
     <link  rel="stylesheet" text="text/scss" href="{{'/assets/css/main.css' | relative_url}}">
+    <title>{{page.title | default: "Scouts 226"}}</title>
 </head>
 
 <body>


### PR DESCRIPTION
Non-ascii characters were not rendering correctly because the content-type did not specify utf-8. Adding the meta charset utf-8 tag to the headers should resolve that issue.